### PR TITLE
Adding clientVersionStalenessDays for startUpdateFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Build with ReasonML. This project is still on beta.
 
 - [x] `startUpdateFlow`  Basic implementation.
 - [ ] Implement event emitter for flexible in-app updates download progress and downloaded status.
-- [ ] Implement `clientVersionStalenessDays` check for `startUpdateFlow`.
+- [x] Implement `clientVersionStalenessDays` check for `startUpdateFlow`.
 
 
 
@@ -53,12 +53,13 @@ try {
 ### Methods
 `startUpdateFlow()`
 ```javascript
-promise string startUpdateFlow(appUpdateType)
+promise string startUpdateFlow(appUpdateType,clientVersionStalenessDays)
 ```
 **Input**
-| Input             | Description                   | Type                      | Default Value 
-| -------------     | -------------                 | -------------             | ------------- |
-| appUpdateType     | Android In-app updates type   | enum(`flexible` or `immediate`)`| `immediate`   |
+| Input             | Description                   | Type                              | Default Value 
+| -------------     | -------------                 | -------------                     | ------------- |
+| appUpdateType     | Android In-app updates type   | enum(`flexible` or `immediate`)   | immediate   |
+| clientVersionStalenessDays     | If an update is available In-app modal will only triger after `x` number of days since the Google Play Store app on the user's device has learnt about an available update.    | `int`   | 0   |
 
 **Promise Resolve**
 | Value                     | Description                            

--- a/android/src/main/java/com/agastya/androidinappupdates/AndroidInappUpdatesModule.java
+++ b/android/src/main/java/com/agastya/androidinappupdates/AndroidInappUpdatesModule.java
@@ -29,13 +29,15 @@ public class AndroidInappUpdatesModule extends ReactContextBaseJavaModule {
         return "AndroidInappUpdates";
     }
 
-    protected void checkUpdate(final Promise promise, int appUpdateType){
+    protected void checkUpdate(final Promise promise, int appUpdateType, int clientVersionStalenessDays){
         AppUpdateManager appUpdateManager = AppUpdateManagerFactory.create(reactContext);
         Task<AppUpdateInfo> appUpdateInfoTask = appUpdateManager.getAppUpdateInfo();
 
         appUpdateInfoTask.addOnSuccessListener(appUpdateInfo -> {
             if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE
-                            && appUpdateInfo.isUpdateTypeAllowed(appUpdateType)) {
+                    && appUpdateInfo.clientVersionStalenessDays() != null
+                    && appUpdateInfo.clientVersionStalenessDays() >= clientVersionStalenessDays
+                    && appUpdateInfo.isUpdateTypeAllowed(appUpdateType)) {
                 AppUpdateOptions options = AppUpdateOptions.newBuilder(appUpdateType).build();
                 final Activity activity = getCurrentActivity();
                 Task<Integer> startUpdateFlow = appUpdateManager.startUpdateFlow(appUpdateInfo,activity,options);
@@ -58,11 +60,9 @@ public class AndroidInappUpdatesModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void checkAppUpdate(int appUpdateType, final Promise promise){
-        checkUpdate(promise, appUpdateType);
+    public void checkAppUpdate(int appUpdateType, int clientVersionStalenessDays, final Promise promise){
+        checkUpdate(promise,appUpdateType,clientVersionStalenessDays);
+
     }
-
-
-
 
 }

--- a/android/src/main/java/com/agastya/androidinappupdates/AndroidInappUpdatesModule.java
+++ b/android/src/main/java/com/agastya/androidinappupdates/AndroidInappUpdatesModule.java
@@ -62,7 +62,6 @@ public class AndroidInappUpdatesModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void checkAppUpdate(int appUpdateType, int clientVersionStalenessDays, final Promise promise){
         checkUpdate(promise,appUpdateType,clientVersionStalenessDays);
-
     }
 
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,1 +1,1 @@
-export function startUpdateFlow(appUpdateType: string): Promise<string>;
+export function startUpdateFlow(appUpdateType: string, clientVersionStalenessDays?: string): Promise<string>;

--- a/src/index.re
+++ b/src/index.re
@@ -1,17 +1,11 @@
 [@bs.module "react-native"]
 [@bs.scope ("NativeModules", "AndroidInappUpdates")]
-external checkAppUpdate: (~appUpdateType: string) => _ = "checkAppUpdate";
-
-[@bs.module "react-native"]
-[@bs.scope ("NativeModules", "AndroidInappUpdates")]
-external checkAppUpdateWithStaleness:
-  (~appUpdateType: string, ~clientVersionStalenessDays: int) => _ =
-  "checkAppUpdateWithStaleness";
+external checkAppUpdate: (int, int) => string = "checkAppUpdate";
 
 let updateFlowDict = Js.Dict.fromList([("IMMEDIATE", 1), ("FLEXIBLE", 0)]);
 
 let startUpdateFlow =
-    (~appUpdateType: string, ~clientVersionStalenessDays: int=0): _ => {
+    (~appUpdateType: string, ~clientVersionStalenessDays: int=0): string => {
   let updateCode =
     switch (
       Js.Dict.get(updateFlowDict, String.uppercase_ascii(appUpdateType))
@@ -19,5 +13,6 @@ let startUpdateFlow =
     | Some(value) => value
     | None => 1
     };
+
   checkAppUpdate(updateCode, clientVersionStalenessDays);
 };

--- a/src/index.re
+++ b/src/index.re
@@ -1,10 +1,17 @@
 [@bs.module "react-native"]
 [@bs.scope ("NativeModules", "AndroidInappUpdates")]
-external checkAppUpdate: int => _ = "checkAppUpdate";
+external checkAppUpdate: (~appUpdateType: string) => _ = "checkAppUpdate";
+
+[@bs.module "react-native"]
+[@bs.scope ("NativeModules", "AndroidInappUpdates")]
+external checkAppUpdateWithStaleness:
+  (~appUpdateType: string, ~clientVersionStalenessDays: int) => _ =
+  "checkAppUpdateWithStaleness";
 
 let updateFlowDict = Js.Dict.fromList([("IMMEDIATE", 1), ("FLEXIBLE", 0)]);
 
-let startUpdateFlow = (appUpdateType: string): string => {
+let startUpdateFlow =
+    (~appUpdateType: string, ~clientVersionStalenessDays: int=0): _ => {
   let updateCode =
     switch (
       Js.Dict.get(updateFlowDict, String.uppercase_ascii(appUpdateType))
@@ -12,5 +19,5 @@ let startUpdateFlow = (appUpdateType: string): string => {
     | Some(value) => value
     | None => 1
     };
-  checkAppUpdate(updateCode);
+  checkAppUpdate(updateCode, clientVersionStalenessDays);
 };


### PR DESCRIPTION
Adding clientVersionStalenessDays for startUpdateFlow. 

If an update is available In-app modal will only triger after `x` number of days since the Google Play Store app on the user's device has learnt about an available update. 